### PR TITLE
Update to add limits on waypoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.lichen911</groupId>
 	<artifactId>Waypoints</artifactId>
-	<version>1.14.0</version>
+	<version>1.15.0</version>
 
 	<build>
 		<plugins>

--- a/src/main/java/io/github/lichen911/waypoints/commands/WpCommand.java
+++ b/src/main/java/io/github/lichen911/waypoints/commands/WpCommand.java
@@ -65,6 +65,15 @@ public class WpCommand implements CommandExecutor {
         if (wpType == WaypointType.PUBLIC) {
             wpLimit = this.permManager.getWaypointLimit(player, wpType, defaultPubWpLimit);
             currentWpCount = this.wpManager.getPublicWaypointsByOwner(playerUuid).size();
+
+            // Check to ensure we stay under the configured server max waypoint limit
+            int totalPublicWaypoints = this.wpManager.getPublicWaypoints().size();
+            int maxPubWpLimit = this.plugin.getConfig().getInt(ConfigPath.serverMaxPublicWaypointLimit);
+            if (totalPublicWaypoints >= maxPubWpLimit && !this.permManager.isAdmin(player)) {
+                player.sendMessage(ChatColor.YELLOW + this.plugin.getResponseMessage(ConfigPath.exceededServerMax)
+                        + ChatColor.WHITE + " (" + ChatColor.YELLOW + maxPubWpLimit + ChatColor.WHITE + ")");
+                return false;
+            }
         } else {
             wpLimit = this.permManager.getWaypointLimit(player, wpType, defaultPrivWpLimit);
             currentWpCount = this.wpManager.getPrivateWaypoints(playerUuid).size();

--- a/src/main/java/io/github/lichen911/waypoints/commands/WpCommand.java
+++ b/src/main/java/io/github/lichen911/waypoints/commands/WpCommand.java
@@ -60,17 +60,21 @@ public class WpCommand implements CommandExecutor {
 
         int wpLimit;
         int currentWpCount;
+        String playerUuid = player.getUniqueId().toString();
 
         if (wpType == WaypointType.PUBLIC) {
             wpLimit = this.permManager.getWaypointLimit(player, wpType, defaultPubWpLimit);
-            currentWpCount = this.wpManager.getPublicWaypoints().size();
+            currentWpCount = this.wpManager.getPublicWaypointsByOwner(playerUuid).size();
         } else {
             wpLimit = this.permManager.getWaypointLimit(player, wpType, defaultPrivWpLimit);
-            currentWpCount = this.wpManager.getPrivateWaypoints(player.getUniqueId().toString()).size();
+            currentWpCount = this.wpManager.getPrivateWaypoints(playerUuid).size();
         }
 
-        if (currentWpCount < wpLimit) {
+        if (currentWpCount < wpLimit || this.permManager.isAdmin(player)) {
             return true;
+        } else {
+            player.sendMessage(ChatColor.YELLOW + this.plugin.getResponseMessage(ConfigPath.waypointLimitExceeded)
+                    + ChatColor.WHITE + " (" + ChatColor.YELLOW + wpLimit + ChatColor.WHITE + ")");
         }
 
         return false;
@@ -88,8 +92,6 @@ public class WpCommand implements CommandExecutor {
                     + ChatColor.WHITE + "' at " + ChatColor.YELLOW + waypoint.getCoordString());
 
             this.wpManager.addWaypoint(waypoint);
-        } else {
-            this.sendNoPermissionMsg(player);
         }
     }
 
@@ -100,7 +102,7 @@ public class WpCommand implements CommandExecutor {
         if (wpType == WaypointType.PUBLIC) {
             // If the waypoint does not have an owner or the player is not the owner then
             // they must have the admin permission to delete it.
-            if ((waypoint.getPlayerUuid() == null || playerUuid != waypoint.getPlayerUuid())
+            if ((waypoint.getPlayerUuid() == null || !playerUuid.equals(waypoint.getPlayerUuid()))
                     && !this.permManager.isAdmin(player)) {
                 this.sendNoPermissionMsg(player);
                 return;

--- a/src/main/java/io/github/lichen911/waypoints/commands/WpCommand.java
+++ b/src/main/java/io/github/lichen911/waypoints/commands/WpCommand.java
@@ -1,5 +1,6 @@
 package io.github.lichen911.waypoints.commands;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.bukkit.Location;
@@ -165,12 +166,18 @@ public class WpCommand implements CommandExecutor {
         String playerUuid = player.getUniqueId().toString();
 
         List<Waypoint> pubWaypoints = this.wpManager.getPublicWaypoints();
+        List<Waypoint> privWaypoints = this.wpManager.getPrivateWaypoints(playerUuid);
+
+        if (this.plugin.getConfig().getBoolean(ConfigPath.sortWaypointList)) {
+            Collections.sort(pubWaypoints, Waypoint.COMPARE_BY_NAME);
+            Collections.sort(privWaypoints, Waypoint.COMPARE_BY_NAME);
+        }
+
         player.sendMessage(ChatColor.RED + WaypointType.PUBLIC.text + " waypoints" + ChatColor.WHITE + ":");
         for (Waypoint wp : pubWaypoints) {
             this.sendWaypointDetailMessage(wp, player, listNames);
         }
 
-        List<Waypoint> privWaypoints = this.wpManager.getPrivateWaypoints(playerUuid);
         player.sendMessage(ChatColor.RED + WaypointType.PRIVATE.text + " waypoints" + ChatColor.WHITE + ":");
         for (Waypoint wp : privWaypoints) {
             this.sendWaypointDetailMessage(wp, player, false);

--- a/src/main/java/io/github/lichen911/waypoints/managers/PermissionManager.java
+++ b/src/main/java/io/github/lichen911/waypoints/managers/PermissionManager.java
@@ -1,11 +1,14 @@
 package io.github.lichen911.waypoints.managers;
 
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import io.github.lichen911.waypoints.enums.WaypointType;
 
 public class PermissionManager {
     private final String permissionPathPrefix = "waypoints";
+    private final String adminPermission = "admin";
+    private final String limitPermission = "limit";
 
     public String getPermissionPath(String cmd, WaypointType wpType) {
         String subCmd = cmd.toString().toLowerCase();
@@ -24,5 +27,25 @@ public class PermissionManager {
             return true;
         }
         return false;
+    }
+
+    public boolean isAdmin(Player player) {
+        if (player.hasPermission(permissionPathPrefix + "." + adminPermission)) {
+            return true;
+        }
+        return false;
+    }
+
+    public int getWaypointLimit(Player player, WaypointType wpType, int defaultValue) {
+        String permPath = permissionPathPrefix + "." + wpType.text + "." + limitPermission + ".";
+
+        for (PermissionAttachmentInfo attachmentInfo : player.getEffectivePermissions()) {
+            String permission = attachmentInfo.getPermission();
+            if (permission.startsWith(permPath)) {
+                return Integer.parseInt(permission.substring(permission.lastIndexOf(".") + 1));
+            }
+        }
+
+        return defaultValue;
     }
 }

--- a/src/main/java/io/github/lichen911/waypoints/managers/PermissionManager.java
+++ b/src/main/java/io/github/lichen911/waypoints/managers/PermissionManager.java
@@ -30,7 +30,7 @@ public class PermissionManager {
     }
 
     public boolean isAdmin(Player player) {
-        if (player.hasPermission(permissionPathPrefix + "." + adminPermission)) {
+        if (player.hasPermission(permissionPathPrefix + "." + adminPermission) || player.isOp()) {
             return true;
         }
         return false;
@@ -41,7 +41,11 @@ public class PermissionManager {
 
         for (PermissionAttachmentInfo attachmentInfo : player.getEffectivePermissions()) {
             String permission = attachmentInfo.getPermission();
-            if (permission.startsWith(permPath)) {
+
+            // With the way we iterate over effect permissions and return at the first
+            // matching instance, we will have unexpected results if multiple permissions
+            // define a limit.
+            if (permission.startsWith(permPath) && attachmentInfo.getValue()) {
                 return Integer.parseInt(permission.substring(permission.lastIndexOf(".") + 1));
             }
         }

--- a/src/main/java/io/github/lichen911/waypoints/managers/PermissionManager.java
+++ b/src/main/java/io/github/lichen911/waypoints/managers/PermissionManager.java
@@ -23,7 +23,7 @@ public class PermissionManager {
     }
 
     public boolean checkHasPermission(Player player, String cmd, WaypointType wpType) {
-        if (player.hasPermission(this.getPermissionPath(cmd, wpType))) {
+        if (player.hasPermission(this.getPermissionPath(cmd, wpType)) || player.isOp()) {
             return true;
         }
         return false;

--- a/src/main/java/io/github/lichen911/waypoints/managers/WaypointManager.java
+++ b/src/main/java/io/github/lichen911/waypoints/managers/WaypointManager.java
@@ -80,7 +80,7 @@ public class WaypointManager {
         return waypoint;
     }
 
-    private List<Waypoint> getWaypointList(String configPrefix, WaypointType wpType) {
+    private List<Waypoint> getWaypointList(String configPrefix, WaypointType wpType, String playerUuid) {
         ConfigurationSection waypointConfigSection = this.wpConfig.getConfig().getConfigurationSection(configPrefix);
 
         List<Waypoint> waypoints = new ArrayList<Waypoint>();
@@ -89,21 +89,38 @@ public class WaypointManager {
 
             for (Map.Entry<String, Object> entry : waypointMap.entrySet()) {
                 String wpName = entry.getKey();
-                String wpLocPath = configPrefix + "." + wpName + "." + configLocPath;
+                String configPrefixWpName = configPrefix + "." + wpName;
+                String wpLocPath = configPrefixWpName + "." + configLocPath;
+                String wpUserName = this.wpConfig.getConfig().getString(configPrefixWpName + "." + configUserPath);
+                String wpOwnerUuid;
                 Location wpLoc = this.wpConfig.getConfig().getLocation(wpLocPath);
-                Waypoint waypoint = new Waypoint(null, null, wpName, wpType, wpLoc);
-                waypoints.add(waypoint);
+
+                if (wpType == WaypointType.PUBLIC) {
+                    wpOwnerUuid = this.wpConfig.getConfig().getString(configPrefixWpName + "." + configPublicOwnerPath);
+                } else {
+                    wpOwnerUuid = playerUuid;
+                }
+
+                Waypoint waypoint = new Waypoint(wpUserName, wpOwnerUuid, wpName, wpType, wpLoc);
+
+                if (playerUuid == null || playerUuid.equals(waypoint.getPlayerUuid())) {
+                    waypoints.add(waypoint);
+                }
             }
         }
         return waypoints;
     }
 
     public List<Waypoint> getPublicWaypoints() {
-        return this.getWaypointList(configPublicPrefix, WaypointType.PUBLIC);
+        return this.getWaypointList(configPublicPrefix, WaypointType.PUBLIC, null);
+    }
+
+    public List<Waypoint> getPublicWaypointsByOwner(String playerUuid) {
+        return this.getWaypointList(configPublicPrefix, WaypointType.PUBLIC, playerUuid);
     }
 
     public List<Waypoint> getPrivateWaypoints(String playerUuid) {
         String configPlayerPath = configPlayersPrefix + "." + playerUuid;
-        return this.getWaypointList(configPlayerPath, WaypointType.PRIVATE);
+        return this.getWaypointList(configPlayerPath, WaypointType.PRIVATE, null);
     }
 }

--- a/src/main/java/io/github/lichen911/waypoints/managers/WaypointManager.java
+++ b/src/main/java/io/github/lichen911/waypoints/managers/WaypointManager.java
@@ -76,8 +76,12 @@ public class WaypointManager {
             playerUuid = this.wpConfig.getConfig().getString(configPath + "." + configPublicOwnerPath);
         }
 
-        Waypoint waypoint = new Waypoint(playerName, playerUuid, wpName, wpType, location);
-        return waypoint;
+        if (location != null) {
+            Waypoint waypoint = new Waypoint(playerName, playerUuid, wpName, wpType, location);
+            return waypoint;
+        }
+
+        return null;
     }
 
     private List<Waypoint> getWaypointList(String configPrefix, WaypointType wpType, String playerUuid) {

--- a/src/main/java/io/github/lichen911/waypoints/managers/WaypointManager.java
+++ b/src/main/java/io/github/lichen911/waypoints/managers/WaypointManager.java
@@ -18,6 +18,7 @@ public class WaypointManager {
     private final String configPlayersPrefix = "waypoints.players";
     private final String configLocPath = "loc";
     private final String configUserPath = "userName";
+    private final String configPublicOwnerPath = "owner";
 
     public WaypointManager(ConfigReader wpConfig) {
         this.wpConfig = wpConfig;
@@ -47,6 +48,12 @@ public class WaypointManager {
 
         this.wpConfig.getConfig().set(configPath + "." + configLocPath, location);
         this.wpConfig.getConfig().set(configPath + "." + configUserPath, playerName);
+
+        // Store the owner's UUID for public waypoints
+        if (wp.getWaypointType() == WaypointType.PUBLIC) {
+            this.wpConfig.getConfig().set(configPath + "." + configPublicOwnerPath, wp.getPlayerUuid());
+        }
+
         this.wpConfig.saveConfig();
     }
 
@@ -62,6 +69,12 @@ public class WaypointManager {
         String configPath = this.getWpConfigPath(playerUuid, wpName, wpType);
         String playerName = this.wpConfig.getConfig().getString(configPath + "." + configUserPath);
         Location location = this.getLocationFromConfig(playerUuid, wpName, wpType);
+
+        // In the case of a public waypoint the returned Waypoint object should have the
+        // playerUuid of the owner of the waypoint
+        if (wpType == WaypointType.PUBLIC) {
+            playerUuid = this.wpConfig.getConfig().getString(configPath + "." + configPublicOwnerPath);
+        }
 
         Waypoint waypoint = new Waypoint(playerName, playerUuid, wpName, wpType, location);
         return waypoint;

--- a/src/main/java/io/github/lichen911/waypoints/objects/Waypoint.java
+++ b/src/main/java/io/github/lichen911/waypoints/objects/Waypoint.java
@@ -1,5 +1,7 @@
 package io.github.lichen911.waypoints.objects;
 
+import java.util.Comparator;
+
 import org.bukkit.Location;
 
 import io.github.lichen911.waypoints.enums.WaypointType;
@@ -10,6 +12,12 @@ public class Waypoint {
     private final String name;
     private final WaypointType type;
     private final Location location;
+
+    public static Comparator<Waypoint> COMPARE_BY_NAME = new Comparator<Waypoint>() {
+        public int compare(Waypoint one, Waypoint other) {
+            return one.name.compareTo(other.name);
+        }
+    };
 
     public Waypoint(String playerName, String playerUuid, String name, WaypointType type, Location location) {
         this.playerName = playerName;

--- a/src/main/java/io/github/lichen911/waypoints/utils/CommandLiteral.java
+++ b/src/main/java/io/github/lichen911/waypoints/utils/CommandLiteral.java
@@ -12,7 +12,9 @@ public final class CommandLiteral {
     public static final String TP = "tp";
     public static final String PUB = "pub";
     public static final String LIST = "list";
+    public static final String LISTNAMES = "listnames";
 
-    public static final List<String> topLevelCmds = new ArrayList<String>(Arrays.asList(ADD, RM, TP, SET, LIST));
+    public static final List<String> topLevelCmds = new ArrayList<String>(
+            Arrays.asList(ADD, RM, TP, SET, LIST, LISTNAMES));
 
 }

--- a/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
+++ b/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
@@ -5,6 +5,7 @@ public class ConfigPath {
     public static final String waypointNotExist = responseMessagesPrefix + "." + "waypointNotExist";
     public static final String playerCmdOnly = responseMessagesPrefix + "." + "playerCmdOnly";
     public static final String noPermission = responseMessagesPrefix + "." + "noPermission";
+    public static final String waypointLimitExceeded = responseMessagesPrefix + "." + "waypointLimitExceeded";
 
     public static final String clickableChatPrefix = "clickableChat";
     public static final String useClickableChat = clickableChatPrefix + "." + "useClickableChat";
@@ -14,4 +15,7 @@ public class ConfigPath {
     public static final String geyserUsernamePrefix = clickableChatPrefix + "." + "geyserUsernamePrefix";
 
     public static final String checkForUpdates = "checkForUpdates";
+    
+    public static final String defaultPublicWaypointLimit = "defaultPublicWaypointLimit";
+    public static final String defaultPrivateWaypointLimit = "defaultPrivateWaypointLimit";
 }

--- a/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
+++ b/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
@@ -7,6 +7,7 @@ public class ConfigPath {
     public static final String noPermission = responseMessagesPrefix + "." + "noPermission";
     public static final String waypointLimitExceeded = responseMessagesPrefix + "." + "waypointLimitExceeded";
     public static final String exceededServerMax = responseMessagesPrefix + "." + "exceededServerMax";
+    public static final String waypointNotOwnedByPlayer = responseMessagesPrefix + "." + "waypointNotOwnedByPlayer";
 
     public static final String clickableChatPrefix = "clickableChat";
     public static final String useClickableChat = clickableChatPrefix + "." + "useClickableChat";

--- a/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
+++ b/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
@@ -6,6 +6,7 @@ public class ConfigPath {
     public static final String playerCmdOnly = responseMessagesPrefix + "." + "playerCmdOnly";
     public static final String noPermission = responseMessagesPrefix + "." + "noPermission";
     public static final String waypointLimitExceeded = responseMessagesPrefix + "." + "waypointLimitExceeded";
+    public static final String exceededServerMax = responseMessagesPrefix + "." + "exceededServerMax";
 
     public static final String clickableChatPrefix = "clickableChat";
     public static final String useClickableChat = clickableChatPrefix + "." + "useClickableChat";
@@ -15,7 +16,8 @@ public class ConfigPath {
     public static final String geyserUsernamePrefix = clickableChatPrefix + "." + "geyserUsernamePrefix";
 
     public static final String checkForUpdates = "checkForUpdates";
-    
+
     public static final String defaultPublicWaypointLimit = "defaultPublicWaypointLimit";
     public static final String defaultPrivateWaypointLimit = "defaultPrivateWaypointLimit";
+    public static final String serverMaxPublicWaypointLimit = "serverMaxPublicWaypointLimit";
 }

--- a/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
+++ b/src/main/java/io/github/lichen911/waypoints/utils/ConfigPath.java
@@ -20,4 +20,6 @@ public class ConfigPath {
     public static final String defaultPublicWaypointLimit = "defaultPublicWaypointLimit";
     public static final String defaultPrivateWaypointLimit = "defaultPrivateWaypointLimit";
     public static final String serverMaxPublicWaypointLimit = "serverMaxPublicWaypointLimit";
+
+    public static final String sortWaypointList = "sortWaypointList";
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,8 +23,16 @@ responseMessages:
   waypointNotExist: Waypoint does not exist
   playerCmdOnly: This command can only be run by a player.
   noPermission: Player does not have permission
+  waypointLimitExceeded: Waypoint limit exceeded
 
 # The following is used to enable / disable the automatic update checker.
 # This does not download updates, it only makes a call to the Spigot API
 # to see if a new version is available. It's only done once during plugin load.
 checkForUpdates: true
+
+# Waypoints maintains a per-user count of both public and private waypoints. The
+# following setting defines how many public / private waypoints are allowed per user.
+# These are the values that are used unless a per-user limit is defined with permissions.
+# Use a large value to effectively disable default limits.
+defaultPublicWaypointLimit: 20
+defaultPrivateWaypointLimit: 20

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,7 @@ responseMessages:
   playerCmdOnly: This command can only be run by a player.
   noPermission: Player does not have permission
   waypointLimitExceeded: Waypoint limit exceeded
+  exceededServerMax: Exceeded server maximum waypoint limit
 
 # The following is used to enable / disable the automatic update checker.
 # This does not download updates, it only makes a call to the Spigot API
@@ -34,5 +35,10 @@ checkForUpdates: true
 # following setting defines how many public / private waypoints are allowed per user.
 # These are the values that are used unless a per-user limit is defined with permissions.
 # Use a large value to effectively disable default limits.
-defaultPublicWaypointLimit: 20
+defaultPublicWaypointLimit: 5
 defaultPrivateWaypointLimit: 20
+
+# The maximum total number of all public waypoints on the server. Even if a user is under
+# their per-user limit they will not be able to add waypoints if the total count meets or exceeds
+# this limit, unless they have admin permission or is an op.
+serverMaxPublicWaypointLimit: 10

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,4 +41,7 @@ defaultPrivateWaypointLimit: 20
 # The maximum total number of all public waypoints on the server. Even if a user is under
 # their per-user limit they will not be able to add waypoints if the total count meets or exceeds
 # this limit, unless they have admin permission or is an op.
-serverMaxPublicWaypointLimit: 10
+serverMaxPublicWaypointLimit: 20
+
+# Should the output of "wp list" be sorted by waypoint name?
+sortWaypointList: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,6 +25,7 @@ responseMessages:
   noPermission: Player does not have permission
   waypointLimitExceeded: Waypoint limit exceeded
   exceededServerMax: Exceeded server maximum waypoint limit
+  waypointNotOwnedByPlayer: Waypoint is not owned by player
 
 # The following is used to enable / disable the automatic update checker.
 # This does not download updates, it only makes a call to the Spigot API

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,11 +2,16 @@ name: ${project.name}
 main: ${project.groupId}.waypoints.Waypoints
 version: ${project.version}
 api-version: 1.20
+author: lichen91
+website: https://www.spigotmc.org/resources/waypoints.114447/
 commands:
   wp:
     description: Manage and use waypoints.
     usage: "/wp"
 permissions:
+  waypoints.admin:
+    description: Admin privileges remove max waypoint limits and allows deleting public waypoints from any owner
+    default: false
   waypoints.private.add:
     description: Allows users to add waypoints to their private list
     default: true
@@ -22,9 +27,6 @@ permissions:
   waypoints.private.set:
     description: Allows users to set their compass heading to a waypoint on their private
     default: true
-  waypoints.private.limit:
-  	description: Determines how many private waypoints are alllowed
-  	default: 10
   waypoints.public.set:
     description: Allows users to set their compass heading to a waypoint on the public list
     default: true
@@ -37,3 +39,7 @@ permissions:
   waypoints.list:
     description: Allows users to list waypoints
     default: true
+  waypoints.private.limit.*:
+    description: Set the max number of allowed private waypoints for a user
+  waypoints.public.limit.*:
+    description: Set the max number of allowed public waypoints for a user

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -39,7 +39,7 @@ permissions:
   waypoints.list:
     description: Allows users to list waypoints
     default: true
-  waypoints.private.limit.*:
+  waypoints.private.limit.#:
     description: Set the max number of allowed private waypoints for a user
-  waypoints.public.limit.*:
+  waypoints.public.limit.#:
     description: Set the max number of allowed public waypoints for a user

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -39,7 +39,9 @@ permissions:
   waypoints.list:
     description: Allows users to list waypoints
     default: true
-  waypoints.private.limit.#:
+  waypoints.private.limit.*:
     description: Set the max number of allowed private waypoints for a user
-  waypoints.public.limit.#:
+    default: false
+  waypoints.public.limit.*:
     description: Set the max number of allowed public waypoints for a user
+    default: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,6 +22,9 @@ permissions:
   waypoints.private.set:
     description: Allows users to set their compass heading to a waypoint on their private
     default: true
+  waypoints.private.limit:
+  	description: Determines how many private waypoints are alllowed
+  	default: 10
   waypoints.public.set:
     description: Allows users to set their compass heading to a waypoint on the public list
     default: true

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,31 @@
+Test cases:
+- list, add, rm, tp, set work with no initial waypoints.yml
+- defaults correctly set when no config.yml
+- list is correctly output
+- add, rm modify private
+- add, rm modify public
+- set, tp private guide correctly
+- set, tp public guide correctly
+- add overwrites existing waypoint
+- last waypoint is stored correctly
+- help message is displayed correctly
+- each permission, public and private
+- messages are correct
+- clickable options in list shows correctly
+- clickable options do correct action
+- config option to disable clickable options
+- config option to run vs suggest clickable options
+- only clickable options have which permission are shown
+- geyser users don't get a menu
+- waypoints.yml correctly formatted
+- config.yml correctly formatted
+- adding new config options updates config.yml with new options without touching old
+- listnames shows player names correctly
+- rm will only let you delete public waypoints owned by player
+- add will not overwrite another player's waypoint
+- must be admin or op to manage waypoints other by other players
+- max public / private waypoint count uses value defined in config
+- max public / private waypoint count will prefer value defined in permission
+- will honor server max waypoint count
+- must be admin or op to go over server max waypoint count
+- waypoint list is sorted


### PR DESCRIPTION
Implemented the following changes:
- Added ownership of public waypoints
- Player may only manage their own public waypoints
- Added `waypoints.admin` permission to allow management of public waypoints owned by others
- Added config options for server max public waypoints
- Added config options for default allowed public and private waypoints
- Added `waypoints.public.limit.#` and `waypoints.private.limit.#` permissions to control max number of waypoints per-user
- Added command to list owners of public waypoints
- Added sorting of waypoint list `wp list`